### PR TITLE
change the chef client default version to v14 in test kitchen

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,7 +5,7 @@ driver:
 
 provisioner:
   product_name: chef
-  product_version: <%= ENV['CHEF_VERSION'] || "current" %>
+  product_version: <%= ENV['CHEF_VERSION'] || "14.0" %>
   install_strategy: once
   deprecations_as_errors: true
 


### PR DESCRIPTION
### Description

Change the default version for test kitchen to provide a better local dev experience.

### Issues Resolved

resolves #48 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] Changes have been added to `CHANGELOG.md`
