### PR TITLE
Add reference to pyenv back to fix the broken link on README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # pyenv Changelog
 
+* Fix broken link in README
 * Follow up tweaks after ownership migration
 
 ## 3.1.1

--- a/README.md
+++ b/README.md
@@ -180,3 +180,5 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 ![https://opencollective.com/sous-chefs/sponsor/7/website](https://opencollective.com/sous-chefs/sponsor/7/avatar.svg?avatarHeight=100)
 ![https://opencollective.com/sous-chefs/sponsor/8/website](https://opencollective.com/sous-chefs/sponsor/8/avatar.svg?avatarHeight=100)
 ![https://opencollective.com/sous-chefs/sponsor/9/website](https://opencollective.com/sous-chefs/sponsor/9/avatar.svg?avatarHeight=100)
+
+[pyenv]: https://github.com/pyenv/pyenv


### PR DESCRIPTION
# Description

Add back a link reference that got accidentally removed at the migration.

## Issues Resolved

N/A

### master
![broken-link](https://user-images.githubusercontent.com/5746693/68501161-56f84700-0212-11ea-853a-1ff036e95b21.png)

### This branch
![fixed-link](https://user-images.githubusercontent.com/5746693/68501204-77c09c80-0212-11ea-90d3-de271a99916f.png)
