### PR TITLE
restore git resource defaults for chef 16

### DIFF
--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -30,6 +30,7 @@ action :install do
   # If we pass in a username, we then install the plugin to the user's home_dir
   # See chef_pyenv_script_helpers.rb for root_path
   git "Install #{new_resource.name} plugin" do
+    checkout_branch 'deploy'
     destination ::File.join(root_path, 'plugins', new_resource.name)
     repository  new_resource.git_url
     reference   new_resource.git_ref

--- a/resources/system_install.rb
+++ b/resources/system_install.rb
@@ -49,6 +49,7 @@ action :install do
   end
 
   git new_resource.global_prefix do
+    checkout_branch 'deploy'
     repository new_resource.git_url
     reference  new_resource.git_ref
     action     :checkout if new_resource.update_pyenv == false

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -49,6 +49,7 @@ action :install do
   end
 
   git new_resource.user_prefix do
+    checkout_branch 'deploy'
     repository new_resource.git_url
     reference  new_resource.git_ref
     user       new_resource.user


### PR DESCRIPTION
Signed-off-by: jtschelling <jt@schelling.io>

# Description

Chef 16 compatibility, and tests are failing currently. Chef 16 removed defaults for `checkout_branch` from the git resource, restore them to the previous default `'deploy'` here https://github.com/chef/chef/commit/165685fdcbd4fbe8138d37d1285b633e3958cf09

## Issues Resolved

N/A

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
