### PR TITLE
Add umask support to pip resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add support for setting umask for pip resource.
 ## 3.4.2 - *2021-06-01*
 
 ## 3.4.1 - *2020-12-31*

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gem 'chef', '~> 15.0'
 
 group :development, :test do
   gem 'cookstyle'
-  gem 'foodcritic'
   gem 'inspec'
   gem 'kitchen-dokken'
   gem 'kitchen-inspec'

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ pyenv_pip 'requests' do
   virtualenv  # Optional: if passed, pip inside provided virtualenv would be used (by default system's pip)
   version     # Optional: if passed, the version the python package to install
   user        # Optional: if passed, the user to install the python module for
+  umask       # Optional: if passed, the umask to set before installing the python module
   options     # Optional: if passed, pip would install/uninstall packages with given options
   requirement # Optional: if true passed, install/uninstall requirements file passed with name property
   editable    # Optional: if true passed, install package in editable mode
@@ -116,6 +117,7 @@ pyenv_script 'foo' do
   pyenv_version # pyenv version to run the script against
   environment   # Optional: Environment to setup to run the script
   user          # Optional: User to run as
+  umask         # Optional: the umask to set before running the script
   group         # Optional: Group to run as
   path          # Optional: Path to search for commands
   returns       # Optional: Expected return code

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -56,7 +56,7 @@ action :install do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
-    umask new_resource.umask if new_resouce.umask
+    umask new_resource.umask if new_resource.umask
     only_if { require_install? }
   end
 end
@@ -80,7 +80,7 @@ action :upgrade do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
-    umask new_resource.umask if new_resouce.umask
+    umask new_resource.umask if new_resource.umask
     only_if { require_upgrade? }
   end
 end
@@ -105,7 +105,7 @@ action :uninstall do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
-    umask new_resource.umask if new_resouce.umask
+    umask new_resource.umask if new_resource.umask
   end
 end
 

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -24,6 +24,7 @@ property :package_name, String, name_property: true
 property :virtualenv,   String
 property :version,      String
 property :user,         String
+property :umask,        [String, Integer]
 property :options,      String
 property :requirement,  [true, false], default: false
 property :editable,     [true, false], default: false
@@ -55,6 +56,7 @@ action :install do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
+    umask new_resource.umask if new_resouce.umask
     only_if { require_install? }
   end
 end
@@ -78,6 +80,7 @@ action :upgrade do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
+    umask new_resource.umask if new_resouce.umask
     only_if { require_upgrade? }
   end
 end
@@ -102,6 +105,7 @@ action :uninstall do
   pyenv_script new_resource.package_name do
     code command
     user new_resource.user if new_resource.user
+    umask new_resource.umask if new_resouce.umask
   end
 end
 


### PR DESCRIPTION
# Description

Adds umask support to pip resource to allow pip to work properly on systems which have a very restrictive umask (like 0077) set.

## Issues Resolved

-

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.  - I don't see how I should test this as the default umask in the test systems is already fine.
- [x] New functionality has been documented in the README if applicable.
