### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- resolved cookstyle error: resources/global.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/pip.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/plugin.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/python.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/rehash.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/script.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/system_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
+- resolved cookstyle error: resources/user_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 ## 3.5.1 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/resources/global.rb
+++ b/resources/global.rb
@@ -25,6 +25,7 @@
 # If we pass in a user check that users global
 
 provides :pyenv_global
+unified_mode true
 
 property :pyenv_version, String, name_property: true
 property :user,          String

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 provides :pyenv_pip
+unified_mode true
 
 property :package_name, String, name_property: true
 property :virtualenv,   String

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 provides :pyenv_plugin
+unified_mode true
 
 property :git_url,     String, required: true
 property :git_ref,     String, default: 'master'

--- a/resources/python.rb
+++ b/resources/python.rb
@@ -21,6 +21,7 @@
 # limitations under the License.
 #
 provides :pyenv_python
+unified_mode true
 
 property :version,      String, name_property: true
 property :version_file, String

--- a/resources/rehash.rb
+++ b/resources/rehash.rb
@@ -21,6 +21,7 @@
 # limitations under the License.
 #
 provides :pyenv_rehash
+unified_mode true
 
 property :user, String
 

--- a/resources/script.rb
+++ b/resources/script.rb
@@ -22,6 +22,7 @@
 #
 
 provides :pyenv_script
+unified_mode true
 
 property :pyenv_version, String
 property :code,          String

--- a/resources/system_install.rb
+++ b/resources/system_install.rb
@@ -20,6 +20,7 @@
 #
 
 provides :pyenv_system_install
+unified_mode true
 
 property :git_url,       String, default: node['pyenv']['git_url']
 property :git_ref,       String, default: node['pyenv']['git_ref']

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -20,6 +20,7 @@
 #
 
 provides :pyenv_user_install
+unified_mode true
 
 property :user,         String, name_property: true
 property :git_url,      String, default: node['pyenv']['git_url']


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.25.10 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with resources/global.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/pip.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/plugin.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/python.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/rehash.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/script.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/system_install.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)

### Issues found and resolved with resources/user_install.rb

 - 1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue` - Set `unified_mode true` in Chef Infra Client 15.3+ custom resources to ensure they work correctly in Chef Infra Client 18 (April 2022) when Unified Mode becomes the default. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_resourcewithoutunifiedtrue)