### PR TITLE
Remove duplicate pyenv init from profile script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove duplicate pyenv init from profile script, fixes "pyenv: cannot rehash: <...>/shims isn't writable" for system install
+
 ## 4.0.1 - *2022-02-08*
 
 - Remove delivery folder

--- a/templates/pyenv.sh
+++ b/templates/pyenv.sh
@@ -13,6 +13,5 @@ fi
 
 if [ -n "$pyenv_root" ]; then
     export PATH="${pyenv_root}/bin:$PATH"
-    eval "$(pyenv init --path)"
     eval "$($pyenv_init)"
 fi


### PR DESCRIPTION
# Description

Fixes "pyenv: cannot rehash: <...>/shims isn't writable" output for a user
when pyenv is system installed. Command 'eval "$(pyenv init -)"'
enables shims, same as 'eval "$(pyenv init --path)"', except later
excludes shell integration and misses '--no-rehash' part.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
