### PR TITLE
Support Ubuntu >= 22.04 and Debian >= 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,56 +1,36 @@
 ---
 name: ci
 
-'on':
+"on":
   pull_request:
   push:
     branches:
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
-          - 'debian-9'
-          - 'debian-10'
-          - 'centos-7'
-          - 'centos-8'
-          - 'oracle-linux'
-          - 'amazon-linux'
-          - 'ubuntu-1804'
-          - 'ubuntu-2004'
+         - 'debian-9'
+         - 'debian-10'
+         - 'debian-11'
+         - 'centos-7'
+         - 'centos-8'
+         - 'oracle-linux'
+         - 'amazon-linux'
+         - 'ubuntu-1804'
+         - 'ubuntu-2004'
+         - 'ubuntu-2204'
+
         suite:
-          - 'system-install'
-          - 'user-install'
+          - system-install
+          - user-install
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
     strategy:
       matrix:
         os:
-         - 'debian-9'
-         - 'debian-10'
-         - 'debian-11'
-         - 'centos-7'
-         - 'centos-8'
-         - 'oracle-linux'
-         - 'amazon-linux'
-         - 'ubuntu-1804'
-         - 'ubuntu-2004'
-         - 'ubuntu-2204'
+          - 'debian-9'
+          - 'debian-10'
+          - 'debian-11'
+          - 'centos-7'
+          - 'centos-8'
+          - 'oracle-linux'
+          - 'amazon-linux'
+          - 'ubuntu-1804'
+          - 'ubuntu-2004'
+          - 'ubuntu-2204'
 
         suite:
           - system-install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 4.1.0 - *2022-07-20*
 
 - Remove duplicate pyenv init from profile script, fixes "pyenv: cannot rehash: <...>/shims isn't writable" for system install
+- Add support for ubuntu 22.04
 
 ## 4.0.1 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## Unreleased
 
+- Add support for ubuntu >= 22.04 and debian >= 11
+
 ## 4.1.0 - *2022-07-20*
 
 - Remove duplicate pyenv init from profile script, fixes "pyenv: cannot rehash: <...>/shims isn't writable" for system install
-- Add support for ubuntu >= 22.04 and debian >= 11
 
 ## 4.0.1 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 4.1.0 - *2022-07-20*
 
 - Remove duplicate pyenv init from profile script, fixes "pyenv: cannot rehash: <...>/shims isn't writable" for system install
-- Add support for ubuntu 22.04
+- Add support for ubuntu >= 22.04 and debian >= 11
 
 ## 4.0.1 - *2022-02-08*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -72,6 +72,13 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
 
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install sudo -y
+
 suites:
   - name: system_install
     run_list:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -28,6 +28,13 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
 
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install sudo -y
+
   - name: centos-7
     driver:
       image: dokken/centos-7
@@ -60,14 +67,14 @@ platforms:
 
   - name: ubuntu-18.04
     driver:
-      image: dokken/ubuntu-16.04
+      image: dokken/ubuntu-18.04
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
 
   - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-20.04
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,6 +22,7 @@ platforms:
   - name: fedora-29
   - name: ubuntu-18.04
   - name: ubuntu-20.04
+  - name: ubuntu-22.04
   - name: opensuse-leap-15
 
 suites:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,6 +16,7 @@ platforms:
     driver_config:
       box: mvbcoding/awslinux
   - name: debian-10
+  - name: debian-11
   - name: centos-7
   - name: centos-8
   - name: oracle-7

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -51,20 +51,17 @@ class PyEnv
       end
 
       def pyenv_prerequisites
-        case node['platform_family']
-        when 'debian'
-          %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev git) << if platform?('ubuntu') && node['lsb']['codename'] == 'jammy'
-            'python3-openssl'
-          else
-            'python-openssl'
-          end
-        when 'rhel', 'fedora', 'amazon'
-          %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils)
-        when 'suse'
-          %w(git git-core zlib-devel bzip2 libbz2-devel libopenssl-devel readline-devel sqlite3 sqlite3-devel xz xz-devel)
-        when 'mac_os_x'
-          %w(git readline xz)
-        end
+        value_for_platform_family(
+        'debian' =>  %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev git) \
+          << value_for_platform(
+            'debian' => { '>= 11' => 'python3-openssl' , 'default' => 'python-openssl' },
+            'ubuntu' => { '>= 22.04' => 'python3-openssl', 'default' => 'python-openssl' },
+            'default' => 'python-openssl'
+          ),
+        ['rhel', 'fedora', 'amazon'] =>  %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils),
+        'suse' => %w(git git-core zlib-devel bzip2 libbz2-devel libopenssl-devel readline-devel sqlite3 sqlite3-devel xz xz-devel),
+        'mac_os_x' => %w(git readline xz),
+        )
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -54,14 +54,14 @@ class PyEnv
         value_for_platform_family(
         'debian' =>  %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev git) \
           << value_for_platform(
-            'debian' => { '>= 11' => 'python3-openssl' , 'default' => 'python-openssl' },
+            'debian' => { '>= 11' => 'python3-openssl', 'default' => 'python-openssl' },
             'ubuntu' => { '>= 22.04' => 'python3-openssl', 'default' => 'python-openssl' },
             'default' => 'python-openssl'
           ),
-        ['rhel', 'fedora', 'amazon'] =>  %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils),
+        %w(rhel fedora amazon) =>  %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils),
         'suse' => %w(git git-core zlib-devel bzip2 libbz2-devel libopenssl-devel readline-devel sqlite3 sqlite3-devel xz xz-devel),
-        'mac_os_x' => %w(git readline xz),
-        )
+        'mac_os_x' => %w(git readline xz)
+      )
       end
     end
   end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -53,7 +53,11 @@ class PyEnv
       def pyenv_prerequisites
         case node['platform_family']
         when 'debian'
-          %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl git)
+          %w(make libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev git) << if platform?('ubuntu') && node['lsb']['codename'] == 'jammy'
+            'python3-openssl'
+          else
+            'python-openssl'
+          end
         when 'rhel', 'fedora', 'amazon'
           %w(git zlib-devel bzip2 bzip2-devel readline-devel sqlite sqlite-devel openssl-devel xz xz-devel libffi-devel findutils)
         when 'suse'


### PR DESCRIPTION
Signed-off-by: Giacomo Bagnoli <giacomo@bagnoli.me>

# Description

Add support for Ubuntu 22.04 by installing `python3-openssl` instead of the old name `python-openssl`
Also added Ubuntu 22.04 to the tests kitchen files

## Issues Resolved

Fixes #95

## Check List

- [X] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
