### PR TITLE
update pyenv.sh to prevent bad PATH modifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@
 - resolved cookstyle error: resources/system_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - resolved cookstyle error: resources/user_install.rb:1:1 refactor: `Chef/Deprecations/ResourceWithoutUnifiedTrue`
 - Removed the pyenv_system_install and pyenv_user_install resources for a singular pyenv_install.
-  - This resource acts like all other resources where it can install both as a user and system wide.
-    Please see the documentation for further information.
+
+   - This resource acts like all other resources where it can install both as a user and system wide.
+     Please see the documentation for further information.
 
 ## 3.5.1 - *2021-08-30*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update `templates/pyenv.sh` script to properly evaluate when to add a user install to `$PATH`
+
 ## 4.2.0 - *2022-09-26*
 
 - Add support for ubuntu >= 22.04 and debian >= 11

--- a/templates/pyenv.sh
+++ b/templates/pyenv.sh
@@ -11,7 +11,7 @@ else
     pyenv_init="pyenv init - --no-rehash"
 fi
 
-if [ -n "$pyenv_root" ]; then
+if [ -d "$pyenv_root" ]; then
     export PATH="${pyenv_root}/bin:$PATH"
     eval "$($pyenv_init)"
 fi


### PR DESCRIPTION
# Description

When pyenv user install is performed for user 1, if user 2 does not have access to user 1's home directory (which is the case on RHEL+clones) user 2 will still get the directory added to its path.

On login, `-bash: pyenv: command not found` will be displayed.

It's not too much of a problem (adding a nonexistent directory to PATH) but it's annoying to see. `-d` will prevent this behavior.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing. (I am testing it in my environments.)
- [ ] New functionality has been documented in the README if applicable.
