### PR TITLE
fix: harden pip shell commands

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,6 +1,7 @@
 class PyEnv
   module Cookbook
     module ScriptHelpers
+      require 'shellwords'
       require 'chef/mixin/shell_out'
 
       include Chef::Mixin::ShellOut
@@ -36,14 +37,16 @@ class PyEnv
         script_env
       end
 
-      def pip_command(command)
+      def pip_command(*arguments)
         pip = if new_resource.virtualenv
                 "#{new_resource.virtualenv}/bin/pip"
               else
                 'pip'
               end
+        pip_arguments = arguments.length == 1 ? Shellwords.split(arguments.first.to_s) : arguments.flatten
+        pip_arguments = pip_arguments.compact.reject { |arg| arg.to_s.empty? }
 
-        shell_out("#{pip} #{command}",
+        shell_out(Shellwords.join([pip, *pip_arguments]),
                   environment: {
                     'PATH' => "#{root_path}/shims:#{ENV['PATH']}",
                   },

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -1,3 +1,5 @@
+require 'shellwords'
+
 unified_mode true
 
 property :package_name,
@@ -42,14 +44,11 @@ action :install do
                      new_resource.package_name
                    end
 
-  pip_args = "install #{new_resource.options} #{install_mode} #{install_target}"
+  pip_args = ['install', *Shellwords.split(new_resource.options.to_s), install_mode, install_target].reject { |arg| arg.to_s.empty? }
 
   # without virtualenv, install package with system's pip
-  command = if new_resource.virtualenv
-              "#{new_resource.virtualenv}/bin/pip #{pip_args}"
-            else
-              "pip #{pip_args}"
-            end
+  pip_executable = new_resource.virtualenv ? "#{new_resource.virtualenv}/bin/pip" : 'pip'
+  command = Shellwords.join([pip_executable, *pip_args])
 
   pyenv_script new_resource.package_name do
     code command
@@ -66,14 +65,11 @@ action :upgrade do
                      new_resource.package_name.to_s
                    end
 
-  pip_args = "install --upgrade #{new_resource.options} #{upgrade_target}"
+  pip_args = ['install', '--upgrade', *Shellwords.split(new_resource.options.to_s), upgrade_target].reject { |arg| arg.to_s.empty? }
 
   # without virtualenv, upgrade package with system's pip
-  command = if new_resource.virtualenv
-              "#{new_resource.virtualenv}/bin/pip #{pip_args}"
-            else
-              "pip #{pip_args}"
-            end
+  pip_executable = new_resource.virtualenv ? "#{new_resource.virtualenv}/bin/pip" : 'pip'
+  command = Shellwords.join([pip_executable, *pip_args])
 
   pyenv_script new_resource.package_name do
     code command
@@ -90,15 +86,11 @@ action :uninstall do
                      ''
                    end
 
-  pip_args = ["uninstall --yes #{new_resource.options}",
-              "#{uninstall_mode} #{new_resource.package_name}"].join
+  pip_args = ['uninstall', '--yes', *Shellwords.split(new_resource.options.to_s), uninstall_mode, new_resource.package_name].reject { |arg| arg.to_s.empty? }
 
   # without virtualenv, uninstall package with system's pip
-  command = if new_resource.virtualenv
-              "#{new_resource.virtualenv}/bin/pip #{pip_args}"
-            else
-              "pip #{pip_args}"
-            end
+  pip_executable = new_resource.virtualenv ? "#{new_resource.virtualenv}/bin/pip" : 'pip'
+  command = Shellwords.join([pip_executable, *pip_args])
 
   pyenv_script new_resource.package_name do
     code command
@@ -131,7 +123,7 @@ action_class do
 
   def get_current_version
     current_version = nil
-    show = pip_command("show #{new_resource.package_name}").stdout
+    show = pip_command('show', new_resource.package_name).stdout
     show.split(/\n+/).each do |line|
       current_version = line.split(/\s+/)[1] if line.start_with?('Version:')
     end


### PR DESCRIPTION
## Summary
- Build pip command lines from argument arrays with Shellwords
- Split options safely and drop empty mode arguments
- Escape virtualenv pip executable and package arguments

## Verification
- cookstyle libraries/helpers.rb resources/pip.rb
- ruby -c libraries/helpers.rb
- ruby -c resources/pip.rb