### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :test do
-  cookbook 'test', path: 'test/fixtures/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+name 'pyenv'
+
+run_list 'test::system_install'
+
+cookbook 'pyenv', path: '.'
+cookbook 'test', path: './test/fixtures/cookbooks/test'
+
+named_run_list :system_install, 'test::system_install'
+named_run_list :user_install, 'test::dokken', 'test::user_install'
+named_run_list :dokken, 'test::dokken'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -10,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   product_version: <%= ENV['CHEF_VERSION'] || "latest" %>
   install_strategy: once
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -30,7 +31,11 @@ suites:
   - name: system_install
     run_list:
       - recipe[test::system_install]
+    provisioner:
+      named_run_list: system_install
   - name: user_install
     run_list:
       - recipe[test::dokken]
       - recipe[test::user_install]
+    provisioner:
+      named_run_list: user_install

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'


### PR DESCRIPTION
## Summary
- replace Berksfile/Berkshelf usage with Policyfile resolution
- map Kitchen suites to Policyfile named run lists
- update Copilot setup to install cookbooks with chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- chef exec rspec --format documentation
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test system-install-ubuntu-2204 --destroy=always
- git diff --check